### PR TITLE
Fix unsafe code and ensure sane usage of randomness

### DIFF
--- a/backend/games/battle_mogs/src/algorithm.rs
+++ b/backend/games/battle_mogs/src/algorithm.rs
@@ -180,9 +180,6 @@ impl Breeding {
 		let mut left_dna = [0u8; 32];
 		let mut right_dna = [0u8; 32];
 
-		let (l1, l2) = left_dna.split_at_mut(16);
-		let (r1, r2) = right_dna.split_at_mut(16);
-
 		let (left_indexes, right_indexes) = match breed_type {
 			BreedType::DomDom => ((0..16, 16..32), (0..16, 16..32)),
 			BreedType::DomRez => ((0..16, 16..32), (16..32, 0..16)),
@@ -190,10 +187,10 @@ impl Breeding {
 			BreedType::RezRez => ((16..32, 0..16), (16..32, 0..16)),
 		};
 
-		l1.copy_from_slice(&left_source_dna[left_indexes.0]);
-		l2.copy_from_slice(&left_source_dna[left_indexes.1]);
-		r1.copy_from_slice(&right_source_dna[right_indexes.0]);
-		r2.copy_from_slice(&right_source_dna[right_indexes.1]);
+		left_dna[0..16].copy_from_slice(&left_source_dna[left_indexes.0]);
+		left_dna[16..32].copy_from_slice(&left_source_dna[left_indexes.1]);
+		right_dna[0..16].copy_from_slice(&right_source_dna[right_indexes.0]);
+		right_dna[16..32].copy_from_slice(&right_source_dna[right_indexes.1]);
 
 		[left_dna, right_dna]
 	}

--- a/backend/games/battle_mogs/src/algorithm.rs
+++ b/backend/games/battle_mogs/src/algorithm.rs
@@ -187,10 +187,10 @@ impl Breeding {
 		let mut right_dna: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
 
 		let (left_indexes, right_indexes) = match breed_type {
-			BreedType::DomDom => ((0..16, 16..32), (0..16, 16..16)),
+			BreedType::DomDom => ((0..16, 16..32), (0..16, 16..32)),
 			BreedType::DomRez => ((0..16, 16..32), (16..32, 0..16)),
-			BreedType::RezDom => ((16..32, 0..16), (16..32, 0..16)),
-			BreedType::RezRez => ((16..32, 0..16), (0..16, 16..32)),
+			BreedType::RezDom => ((16..32, 0..16), (0..16, 16..32)),
+			BreedType::RezRez => ((16..32, 0..16), (16..32, 0..16)),
 		};
 
 		unsafe {
@@ -477,6 +477,86 @@ impl Generation {
 #[cfg(test)]
 mod test {
 	use super::*;
+
+	mod pairing {
+		use super::*;
+
+		#[test]
+		fn pairing_dom_dom_works() {
+			let breed_type = BreedType::DomDom;
+
+			let left_dna: [u8; 32] = core::array::from_fn(|i| i as u8 + 1); // [1..32]
+			let right_dna = core::array::from_fn(|i| i as u8 + 33); // [33..64]
+
+			let result = Breeding::pairing(breed_type, &left_dna, &right_dna);
+
+			assert_eq!(result[0], left_dna);
+			assert_eq!(result[1], right_dna);
+		}
+
+		#[test]
+		fn pairing_dom_rez_works() {
+			let breed_type = BreedType::DomRez;
+
+			let left_dna: [u8; 32] = core::array::from_fn(|i| i as u8 + 1); // [1..32]
+			let right_dna = core::array::from_fn(|i| i as u8 + 33); // [33..64]
+
+			let result = Breeding::pairing(breed_type, &left_dna, &right_dna);
+
+			assert_eq!(result[0], left_dna);
+			assert_eq!(
+				result[1],
+				[
+					49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 33, 34, 35, 36,
+					37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48
+				]
+			);
+		}
+
+		#[test]
+		fn pairing_rez_dom_works() {
+			let breed_type = BreedType::RezDom;
+
+			let left_dna: [u8; 32] = core::array::from_fn(|i| i as u8 + 1); // [1..32]
+			let right_dna = core::array::from_fn(|i| i as u8 + 33); // [33..64]
+
+			let result = Breeding::pairing(breed_type, &left_dna, &right_dna);
+
+			assert_eq!(
+				result[0],
+				[
+					17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 1, 2, 3, 4, 5,
+					6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+				]
+			);
+			assert_eq!(result[1], right_dna);
+		}
+
+		#[test]
+		fn pairing_rez_rez_works() {
+			let breed_type = BreedType::RezRez;
+
+			let left_dna: [u8; 32] = core::array::from_fn(|i| i as u8 + 1); // [1..32]
+			let right_dna = core::array::from_fn(|i| i as u8 + 33); // [33..64]
+
+			let result = Breeding::pairing(breed_type, &left_dna, &right_dna);
+
+			assert_eq!(
+				result[0],
+				[
+					17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 1, 2, 3, 4, 5,
+					6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+				]
+			);
+			assert_eq!(
+				result[1],
+				[
+					49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 33, 34, 35, 36,
+					37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48
+				]
+			);
+		}
+	}
 
 	mod segmenting {
 		use super::*;

--- a/backend/games/battle_mogs/src/algorithm.rs
+++ b/backend/games/battle_mogs/src/algorithm.rs
@@ -195,7 +195,7 @@ impl Breeding {
 		[left_dna, right_dna]
 	}
 
-	pub fn segmenting(input_dna: [[u8; 32]; 2], block_hash: [u8; 32]) -> [[u8; 32]; 2] {
+	pub fn segmenting(input_dna: [[u8; 32]; 2], random_hash: [u8; 32]) -> [[u8; 32]; 2] {
 		let stats_segment = &input_dna[0];
 		let visuals_segment = &input_dna[1];
 
@@ -223,8 +223,8 @@ impl Breeding {
 			let stats_bit = Binary::get_bit_at(stats_segment_2_1[byte_index], bit_index);
 			let visuals_bit = Binary::get_bit_at(visuals_segment_1_1[byte_index], bit_index);
 
-			let block_hash_bit_1 = Binary::get_bit_at(block_hash[byte_index], bit_index);
-			let block_hash_bit_2 = Binary::get_bit_at(block_hash[j / 8], (j % 8) as u8);
+			let random_hash_bit_1 = Binary::get_bit_at(random_hash[byte_index], bit_index);
+			let random_hash_bit_2 = Binary::get_bit_at(random_hash[j / 8], (j % 8) as u8);
 
 			let half_i = i / 2;
 			let mut stats_half_byte: u8 = output_stats[half_i];
@@ -240,12 +240,12 @@ impl Breeding {
 
 			match (stats_bit, visuals_bit) {
 				(true, false) => {
-					if block_hash_bit_1 {
+					if random_hash_bit_1 {
 						stats_half_byte =
 							Binary::copy_bits(stats_half_byte, stats_segment_byte, mask_side); // A+ as 4
 						stats_half_byte = Binary::add_one(stats_half_byte, mask_side);
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0x44, mask_side);
-					} else if !block_hash_bit_2 {
+					} else if !random_hash_bit_2 {
 						stats_half_byte =
 							Binary::copy_bits(stats_half_byte, stats_segment_byte, mask_side); // A as A
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0xAA, mask_side);
@@ -259,12 +259,12 @@ impl Breeding {
 					}
 				},
 				(false, true) => {
-					if block_hash_bit_2 {
+					if random_hash_bit_2 {
 						stats_half_byte =
 							Binary::copy_bits(stats_half_byte, visuals_segment_byte, mask_side); // 8
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0x88, mask_side);
 						stats_half_byte = Binary::add_one(stats_half_byte, mask_side);
-					} else if !block_hash_bit_1 {
+					} else if !random_hash_bit_1 {
 						stats_half_byte =
 							Binary::copy_bits(stats_half_byte, visuals_segment_byte, mask_side); // B
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0xBB, mask_side);
@@ -278,7 +278,7 @@ impl Breeding {
 					}
 				},
 				(false, false) => {
-					if !block_hash_bit_1 && !block_hash_bit_2 {
+					if !random_hash_bit_1 && !random_hash_bit_2 {
 						if !stats_bit & visuals_bit {
 							stats_half_byte = Binary::copy_bits(
 								stats_half_byte,
@@ -298,11 +298,11 @@ impl Breeding {
 								Binary::copy_bits(visuals_half_byte, 0x00, mask_side);
 							stats_half_byte = Binary::sub_one(stats_half_byte, mask_side);
 						}
-					} else if block_hash_bit_1 && block_hash_bit_2 {
+					} else if random_hash_bit_1 && random_hash_bit_2 {
 						stats_half_byte =
-							Binary::copy_bits(stats_half_byte, !block_hash[i % 32], mask_side); // !blk as E
+							Binary::copy_bits(stats_half_byte, !random_hash[i % 32], mask_side); // !blk as E
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0xEE, mask_side);
-					} else if block_hash_bit_1 {
+					} else if random_hash_bit_1 {
 						stats_half_byte =
 							Binary::copy_bits(stats_half_byte, stats_segment_byte, mask_side); // A
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0xAA, mask_side);
@@ -313,7 +313,7 @@ impl Breeding {
 					}
 				},
 				(true, true) => {
-					if block_hash_bit_1 && block_hash_bit_2 {
+					if random_hash_bit_1 && random_hash_bit_2 {
 						stats_half_byte = Binary::copy_bits(
 							stats_half_byte,
 							stats_segment_byte | visuals_segment_byte,
@@ -321,11 +321,11 @@ impl Breeding {
 						); // |+ as C
 						stats_half_byte = Binary::add_one(stats_half_byte, mask_side);
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0xCC, mask_side);
-					} else if !block_hash_bit_1 && !block_hash_bit_2 {
+					} else if !random_hash_bit_1 && !random_hash_bit_2 {
 						stats_half_byte =
-							Binary::copy_bits(stats_half_byte, block_hash[i % 32], mask_side); // blk as F
+							Binary::copy_bits(stats_half_byte, random_hash[i % 32], mask_side); // blk as F
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0xFF, mask_side);
-					} else if block_hash_bit_1 {
+					} else if random_hash_bit_1 {
 						stats_half_byte =
 							Binary::copy_bits(stats_half_byte, stats_segment_byte, mask_side); // A
 						visuals_half_byte = Binary::copy_bits(visuals_half_byte, 0xAA, mask_side);
@@ -343,7 +343,7 @@ impl Breeding {
 			// recombination
 			if mask_side == BitMaskSide::Right {
 				if stats_byte == 0xFF || stats_byte == 0x00 {
-					stats_byte &= block_hash[i % 32];
+					stats_byte &= random_hash[i % 32];
 					visuals_byte = 0x33;
 				}
 				output_stats[i / 2] = stats_byte;

--- a/backend/games/battle_mogs/src/algorithm.rs
+++ b/backend/games/battle_mogs/src/algorithm.rs
@@ -167,7 +167,7 @@ impl Breeding {
 		final_dna[0..8].copy_from_slice(&left_source_dna[left_indexes.0]);
 		final_dna[8..16].copy_from_slice(&left_source_dna[left_indexes.1]);
 		final_dna[16..24].copy_from_slice(&right_source_dna[right_indexes.0]);
-		final_dna[24.. 32].copy_from_slice(&right_source_dna[right_indexes.1]);
+		final_dna[24..32].copy_from_slice(&right_source_dna[right_indexes.1]);
 
 		final_dna
 	}

--- a/backend/games/battle_mogs/src/algorithm.rs
+++ b/backend/games/battle_mogs/src/algorithm.rs
@@ -383,7 +383,7 @@ impl Breeding {
 			for i in 0..max_rarity {
 				if rand[i as usize] > prob {
 					result = i;
-					break
+					break;
 				}
 			}
 		}
@@ -436,33 +436,30 @@ impl Generation {
 		input_rarity_1: RarityType,
 		input_generation_2: MogwaiGeneration,
 		input_rarity_2: RarityType,
-		random_hash: &[u8],
+		random_hash: &[u8; 32],
 	) -> (RarityType, MogwaiGeneration, RarityType) {
-		let mut resulting_gen = MogwaiGeneration::default();
-		let mut resulting_rarity = RarityType::default();
 
-		if random_hash.len() >= 12 {
-			let base_rarity = (input_rarity_1 as u16 + input_rarity_2 as u16).saturating_sub(2) / 2;
+		let base_rarity = (input_rarity_1 as u16 + input_rarity_2 as u16).saturating_sub(2) / 2;
 
-			let slice = unsafe { &*(&random_hash[0..6] as *const [u8] as *const [u8; 6]) };
-			let (out_rarity_1, out_gen_1) =
-				Self::compute_next_generation_and_rarity(input_generation_1, input_rarity_1, slice);
+		let mut rarity_1_input_hash: [u8; 6] = [0u8; 6];
+		rarity_1_input_hash.copy_from_slice(&random_hash[0..6]);
+		let (out_rarity_1, out_gen_1) =
+			Self::compute_next_generation_and_rarity(input_generation_1, input_rarity_1, &rarity_1_input_hash);
 
-			let slice = unsafe { &*(&random_hash[6..12] as *const [u8] as *const [u8; 6]) };
-			let (out_rarity_2, out_gen_2) =
-				Self::compute_next_generation_and_rarity(input_generation_2, input_rarity_2, slice);
+		let mut rarity_2_input_hash: [u8; 6] = [0u8; 6];
+		rarity_2_input_hash.copy_from_slice(&random_hash[6..12]);
+		let (out_rarity_2, out_gen_2) =
+			Self::compute_next_generation_and_rarity(input_generation_2, input_rarity_2, &rarity_2_input_hash);
 
-			resulting_gen = MogwaiGeneration::coerce_from(
-				(out_gen_1 as u16 + out_gen_2 as u16 + base_rarity) / 2,
-			);
+		let resulting_gen =
+			MogwaiGeneration::coerce_from((out_gen_1 as u16 + out_gen_2 as u16 + base_rarity) / 2);
 
-			resulting_rarity = RarityType::from(
-				((out_rarity_1 as u16 +
-					out_rarity_2 as u16 +
-					((input_rarity_1 as u16 + input_rarity_2 as u16) / 2)) /
-					2) % 5,
-			)
-		}
+		let resulting_rarity = RarityType::from(
+			((out_rarity_1 as u16 +
+				out_rarity_2 as u16 +
+				((input_rarity_1 as u16 + input_rarity_2 as u16) / 2)) /
+				2) % 5,
+		);
 
 		let max_rarity = RarityType::from(
 			(6 + ((input_rarity_1 as u16 + input_rarity_2 as u16) / 2_u16) / 2) % 5,

--- a/backend/games/battle_mogs/src/algorithm.rs
+++ b/backend/games/battle_mogs/src/algorithm.rs
@@ -183,8 +183,11 @@ impl Breeding {
 		left_source_dna: &[u8; 32],
 		right_source_dna: &[u8; 32],
 	) -> [[u8; 32]; 2] {
-		let mut left_dna: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
-		let mut right_dna: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
+		let mut left_dna = [0u8; 32];
+		let mut right_dna = [0u8; 32];
+
+		let (l1, l2) = left_dna.split_at_mut(16);
+		let (r1, r2) = right_dna.split_at_mut(16);
 
 		let (left_indexes, right_indexes) = match breed_type {
 			BreedType::DomDom => ((0..16, 16..32), (0..16, 16..32)),
@@ -193,17 +196,12 @@ impl Breeding {
 			BreedType::RezRez => ((16..32, 0..16), (16..32, 0..16)),
 		};
 
-		unsafe {
-			let l_dna_ptr = left_dna.as_mut_ptr() as *mut u8;
-			let r_dna_ptr = right_dna.as_mut_ptr() as *mut u8;
+		l1.copy_from_slice(&left_source_dna[left_indexes.0]);
+		l2.copy_from_slice(&left_source_dna[left_indexes.1]);
+		r1.copy_from_slice(&right_source_dna[right_indexes.0]);
+		r2.copy_from_slice(&right_source_dna[right_indexes.1]);
 
-			copy_nonoverlapping(left_source_dna[left_indexes.0].as_ptr(), l_dna_ptr, 16);
-			copy_nonoverlapping(left_source_dna[left_indexes.1].as_ptr(), l_dna_ptr.add(16), 16);
-			copy_nonoverlapping(right_source_dna[right_indexes.0].as_ptr(), r_dna_ptr, 16);
-			copy_nonoverlapping(right_source_dna[right_indexes.1].as_ptr(), r_dna_ptr.add(16), 16);
-
-			[left_dna.assume_init(), right_dna.assume_init()]
-		}
+		[left_dna, right_dna]
 	}
 
 	pub fn segmenting(input_dna: [[u8; 32]; 2], block_hash: [u8; 32]) -> [[u8; 32]; 2] {

--- a/backend/games/battle_mogs/src/transitions/breed.rs
+++ b/backend/games/battle_mogs/src/transitions/breed.rs
@@ -79,7 +79,11 @@ where
 		let mut table_asset = Self::get_owned_achievement_table(owner, table_id)?;
 
 		let mogwai_id = Self::new_asset_id()?;
-		let next_gen_hash = Sage::random_hash(b"breed_next_gen").0;
+
+		// `next_gen_hash` is static for the duration of one block per unique
+		// owner/mogwai_id pair.
+		let subject = (owner, mogwai_id, b"breed_next_gen").encode();
+		let next_gen_hash = Sage::random_hash(&subject).0;
 
 		let (rarity, next_gen, max_rarity) = Generation::next_gen(
 			mogwai_1.generation,

--- a/backend/games/battle_mogs/src/transitions/create.rs
+++ b/backend/games/battle_mogs/src/transitions/create.rs
@@ -55,24 +55,21 @@ where
 		let block_number = Sage::get_current_block_number();
 		let mogwai_id = Self::new_asset_id()?;
 
-		let random_hash_1 = Sage::random_hash(b"create_mogwai");
-		let random_hash_2 = Sage::random_hash(b"extend_mogwai");
+		let random_dna_1 = Sage::random_hash(b"create_mogwai");
+		let random_dna_2 = Sage::random_hash(b"extend_mogwai");
 
 		let (rarity, next_gen, max_rarity) = Generation::next_gen(
 			MogwaiGeneration::First,
 			RarityType::Common,
 			MogwaiGeneration::First,
 			RarityType::Common,
-			&random_hash_1.0,
+			&random_dna_1.0,
 		);
 		let rarity = RarityType::from(((max_rarity as u8) << 4) + rarity as u8);
 
 		let breed_type = BreedType::calculate_breed_type::<BlockNumber>(block_number);
 
-		let dx = unsafe { &*(&random_hash_1.as_ref()[0..32] as *const [u8] as *const [u8; 32]) };
-		let dy = unsafe { &*(&random_hash_2.as_ref()[0..32] as *const [u8] as *const [u8; 32]) };
-
-		let final_dna = Breeding::pairing(breed_type, dx, dy);
+		let final_dna = Breeding::pairing(breed_type, & random_dna_1.0, &random_dna_2.0);
 
 		let mogwai =
 			MogwaiVariant { dna: final_dna, generation: next_gen, rarity, phase: PhaseType::Bred };

--- a/backend/games/battle_mogs/src/transitions/create.rs
+++ b/backend/games/battle_mogs/src/transitions/create.rs
@@ -63,7 +63,7 @@ where
 			RarityType::Common,
 			MogwaiGeneration::First,
 			RarityType::Common,
-			random_hash_1.as_ref(),
+			&random_hash_1.0,
 		);
 		let rarity = RarityType::from(((max_rarity as u8) << 4) + rarity as u8);
 

--- a/backend/games/battle_mogs/src/transitions/create.rs
+++ b/backend/games/battle_mogs/src/transitions/create.rs
@@ -55,8 +55,11 @@ where
 		let block_number = Sage::get_current_block_number();
 		let mogwai_id = Self::new_asset_id()?;
 
-		let random_dna_1 = Sage::random_hash(b"create_mogwai");
-		let random_dna_2 = Sage::random_hash(b"extend_mogwai");
+		// random_dna_1/2 are static for the duration of one block for a specific account.
+		// We could include the `mogwai_id` in the subject to enable creating multiple different
+		// mogwais per block for one owner, but we want to prevent bot farming.
+		let random_dna_1 = Sage::random_hash(&(owner, b"create_mogwai").encode());
+		let random_dna_2 = Sage::random_hash(&(owner, b"extend_mogwai").encode());
 
 		let (rarity, next_gen, max_rarity) = Generation::next_gen(
 			MogwaiGeneration::First,

--- a/backend/games/battle_mogs/src/transitions/create.rs
+++ b/backend/games/battle_mogs/src/transitions/create.rs
@@ -69,7 +69,7 @@ where
 
 		let breed_type = BreedType::calculate_breed_type::<BlockNumber>(block_number);
 
-		let final_dna = Breeding::pairing(breed_type, & random_dna_1.0, &random_dna_2.0);
+		let final_dna = Breeding::pairing(breed_type, &random_dna_1.0, &random_dna_2.0);
 
 		let mogwai =
 			MogwaiVariant { dna: final_dna, generation: next_gen, rarity, phase: PhaseType::Bred };

--- a/backend/games/battle_mogs/src/transitions/hatch.rs
+++ b/backend/games/battle_mogs/src/transitions/hatch.rs
@@ -72,8 +72,8 @@ where
 
 		// `block_hash` is static for the duration of one block per unique owner, mogwai_id pair.
 		let subject = (owner, mogwai_id, b"mogwai_hatch").encode();
-		let block_hash = Sage::random_hash(&subject).0;
-		let (dna, rarity) = Self::segment_and_bake(mogwai, block_hash);
+		let random_hash = Sage::random_hash(&subject).0;
+		let (dna, rarity) = Self::segment_and_bake(mogwai, random_hash);
 
 		mogwai.phase = PhaseType::Hatched;
 		mogwai.rarity = rarity;

--- a/backend/games/battle_mogs/src/transitions/hatch.rs
+++ b/backend/games/battle_mogs/src/transitions/hatch.rs
@@ -70,7 +70,9 @@ where
 		let mogwai = asset.as_mogwai()?;
 		ensure!(mogwai.phase == PhaseType::Bred, BattleMogsError::from(MOGWAI_NOT_IN_BRED_PHASE));
 
-		let block_hash = Sage::random_hash(b"mogwai_hatch").0;
+		// `block_hash` is static for the duration of one block per unique owner, mogwai_id pair.
+		let subject = (owner, mogwai_id, b"mogwai_hatch").encode();
+		let block_hash = Sage::random_hash(&subject).0;
 		let (dna, rarity) = Self::segment_and_bake(mogwai, block_hash);
 
 		mogwai.phase = PhaseType::Hatched;

--- a/backend/games/battle_mogs/src/transitions/hatch.rs
+++ b/backend/games/battle_mogs/src/transitions/hatch.rs
@@ -36,7 +36,6 @@ use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, BlockNumber as BlockNumberT, Member},
 	SaturatedConversion,
 };
-use sp_std::{mem::MaybeUninit, ptr::copy_nonoverlapping};
 
 impl<AccountId, BlockNumber, Balance, Sage> BattleMogsTransition<AccountId, BlockNumber, Sage>
 where
@@ -72,7 +71,7 @@ where
 		ensure!(mogwai.phase == PhaseType::Bred, BattleMogsError::from(MOGWAI_NOT_IN_BRED_PHASE));
 
 		let block_hash = Sage::random_hash(b"mogwai_hatch").0;
-		let (dna, rarity) = Self::segment_and_bake(mogwai, &block_hash);
+		let (dna, rarity) = Self::segment_and_bake(mogwai, block_hash);
 
 		mogwai.phase = PhaseType::Hatched;
 		mogwai.rarity = rarity;
@@ -87,15 +86,7 @@ where
 		])
 	}
 
-	fn segment_and_bake(mogwai: &mut Mogwai, hash: &[u8; 32]) -> ([[u8; 32]; 2], RarityType) {
-		let block_hash = unsafe {
-			let mut block_hash: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
-			let block_hash_ptr = block_hash.as_mut_ptr() as *mut u8;
-			copy_nonoverlapping(hash.as_ref()[0..32].as_ptr(), block_hash_ptr, 32);
-			block_hash.assume_init()
-		};
-
-		// segment and bake the hatched mogwai
-		(Breeding::segmenting(mogwai.dna, block_hash), Breeding::bake(mogwai.rarity, block_hash))
+	fn segment_and_bake(mogwai: &mut Mogwai, hash: [u8; 32]) -> ([[u8; 32]; 2], RarityType) {
+		(Breeding::segmenting(mogwai.dna, hash), Breeding::bake(mogwai.rarity, hash))
 	}
 }

--- a/backend/games/battle_mogs/src/transitions/morph.rs
+++ b/backend/games/battle_mogs/src/transitions/morph.rs
@@ -62,10 +62,14 @@ where
 
 		let block_number = Sage::get_current_block_number();
 		let breed_type = BreedType::calculate_breed_type(block_number);
-		let dx = unsafe { &*(&mogwai.dna[0][0..16] as *const [u8] as *const [u8; 16]) };
-		let dy = unsafe { &*(&mogwai.dna[0][16..32] as *const [u8] as *const [u8; 16]) };
 
-		mogwai.dna[0] = Breeding::morph(breed_type, dx, dy);
+		let mut dx = [0u8; 16];
+		dx.copy_from_slice(&mogwai.dna[0][0..16]);
+
+		let mut dy = [0u8; 16];
+		dy.copy_from_slice(&mogwai.dna[0][16..32]);
+
+		mogwai.dna[0] = Breeding::morph(breed_type, &dx, &dy);
 
 		let table = table_asset.as_achievement()?;
 		table.morpheus = table.morpheus.increase_by(1);

--- a/backend/games/casino_jam/src/transition/mod.rs
+++ b/backend/games/casino_jam/src/transition/mod.rs
@@ -338,7 +338,10 @@ where
 				}
 
 				// Now we spin the machine!
-				let hash = Sage::random_hash(b"casino_gamble").0;
+
+				// The hash is static for the duration of one block per bandit_id. So it does not
+				// make sense for a player to play more than once per block on one bandit.
+				let hash = Sage::random_hash(&(bandit_id, b"casino_gamble").encode()).0;
 				let full_spins = {
 					let maybe_full_spins = CasinoJamUtils::spins(
 						spin_times as u8,


### PR DESCRIPTION
I made some changes to the subject that guarantee that the random hash is unique enough. Before it was the same output for whoever called a specific function, e.g.:

* All Mogwais created in the same block were identical. Now they are unique per account
* The output of the breeding function was the same all breeding operations per block. Now it is unique per account.
* The `next_gen_hash` was identicial. Now it is unique per mogwai. (I am not sure if we care here though, as there are quite some operations that are performed subsequently. And those operations are already unique for the input DNA).
* The input random input of segmenting was the same for the entirety of a block. Now it is unique per account. (But this is probably not relevant either.)
* In casino JAM, machines with identical specs produced the same output. Now the unique bandit id is part of the random subject, and therefore ensures that identical machines have a different output within the same block.